### PR TITLE
Add "Notable works" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-+0n0xVW2eSR5OomGNYDnhzAbDsOXxcvSN1TPprVMTNDbiYZCxYbOOl7+AMvyTG2x" crossorigin="anonymous">
 
-    <!-- Inter font -->
+    <!-- Inter font and Roboto Mono for <code> font -->
     <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&family=Roboto+Mono&display=swap" rel="stylesheet">
 
     <!-- FA icons -->
     <script src="https://kit.fontawesome.com/405d3dabf9.js" crossorigin="anonymous"></script>
@@ -54,7 +54,7 @@
           </div>
 
           <div class="col-md content-description-col-right order-md-2">
-            <p>I like contributing to open-source projects, be it small translational contributions, README changes or feature additions.</p>
+            <p>I like contributing to open-source projects, be it small translational contributions, <code>README</code> changes or feature additions.</p>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -73,14 +73,36 @@
       </div>
     </div>
 
+    <div class="content-area" id="notable-works-content-area">
+      <div class="container">
+        <h1>Notable works</h1>
+        <div class="content-description-page">
+          <!-- TODO: Show artwork -->
+
+          <p><strong>Small steps in accessibility</strong>:
+          I am a strong advocate of general design patterns that benefit the end-user in terms of accesability however small the feature/design.
+          This is why a lot of my interest diverted to helping some of <a class="link link-blueberry" href="https://elementary.io/">elementaryOS</a>'s open issues in
+          implementing design patterns that make the overall desktop experience more user-friendly for their 6.0 release such as
+
+            <ul>
+              <li>Adding tooltip text to the
+                  <a class="link link-blueberry" href="https://github.com/elementary/wingpanel-indicator-notifications/pull/175">Notifications</a>,
+                  <a class="link link-blueberry" href="https://github.com/elementary/wingpanel-indicator-network/pull/199">Network</a>,
+                  <a class="link link-blueberry" href="https://github.com/elementary/wingpanel-indicator-bluetooth/pull/148">Bluetooth</a> and
+                  <a class="link link-blueberry" href="https://github.com/elementary/wingpanel-indicator-session/pull/151">Session</a> indicator
+              </li>
+              <li>Allowing users to <a class="link link-blueberry" href="https://github.com/elementary/sideload/pull/110">trash</a> their <code>.flatpakref</code> file after installing a flatpak</li>
+              <li>View <a class="link link-blueberry" href="https://github.com/elementary/onboarding/pull/127">last viewed</a> interactive page of the desktop onboarding app</li>
+            </ul>
+          </p>
+        </div>
+      </div>
+    </div>
+
     <div class="content-area" id="footer">
       <div class="container">
-        <div class="row align-items-center">
-          <div class="col">
-            <p>Made with elementaryOS's <a class="link link-blueberry" href="https://elementary.io/brand#color">colour palette</a><br>
-            <a class="link link-silver" href="https://github.com/pongloongyeat/pongloongyeat.github.io"><i class="fab fa-1x fa-github"></i>View website source</a></p>
-          </div>
-        </div>
+        <p>Made with elementaryOS's <a class="link link-blueberry" href="https://elementary.io/brand#color">colour palette</a><br>
+        <a class="link link-silver" href="https://github.com/pongloongyeat/pongloongyeat.github.io"><i class="fab fa-1x fa-github"></i>View website source</a></p>
       </div>
     </div>
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -245,16 +245,18 @@ li {
 
 .content-description-page {
     /* This class is mostly used for full-length
-    content (i.e. no columns) */
-    padding: 0 12px 64px 12px;
-}
-
-.content-description-page p {
+    content (i.e. no columns). Justify is used
+    here since on mobile, the text is squreezed
+    and so it looks like there is quite a fair
+    amount of text and less "blank whitespaces"
+    in between words. */
     text-align: justify;
+    padding: 0 12px 64px 12px;
 }
 
 @media (min-width: 768px) {
     .content-description-page {
+        text-align: start;
         padding: 0px;
         margin: 0 128px 64px 128px;
     }

--- a/styles/style.css
+++ b/styles/style.css
@@ -102,8 +102,23 @@ i {
     padding-left: 0;
 }
 
+img {
+    max-width: calc(100vw - 48px);
+}
+
+@media (min-width: 768px) {
+    img {
+        max-width: calc(100vw - 256px);
+    }
+}
+
 code {
     font-family: 'Roboto Mono', monospace;
+    font-size: 20px;
+}
+
+li {
+    text-align: left;
     font-size: 20px;
 }
 
@@ -220,6 +235,29 @@ code {
         text-align: start;
         margin-right: 128px;
     }
+}
+
+.content-description-page {
+    /* This class is mostly used for full-length
+    content (i.e. no columns) */
+    padding: 0 12px 0 12px;
+}
+
+.content-description-page p {
+    text-align: justify;
+}
+
+@media (min-width: 768px) {
+    .content-description-page {
+        padding: 0px;
+        margin: 0 128px 0 128px;
+    }
+}
+
+#notable-works-content-area {
+    padding-top: 0;
+    padding-bottom: 0;
+    height: auto;
 }
 
 #footer {

--- a/styles/style.css
+++ b/styles/style.css
@@ -113,13 +113,19 @@ img {
 }
 
 code {
+    /* Inter Mono isn't readily available yet
+    but Roboto Mono pairs quite well with it */
     font-family: 'Roboto Mono', monospace;
+    font-size: inherit;
+}
+
+ul, ol {
+    text-align: left;
     font-size: 20px;
 }
 
 li {
-    text-align: left;
-    font-size: 20px;
+    font-size: inherit;
 }
 
 .about-area {
@@ -240,7 +246,7 @@ li {
 .content-description-page {
     /* This class is mostly used for full-length
     content (i.e. no columns) */
-    padding: 0 12px 0 12px;
+    padding: 0 12px 64px 12px;
 }
 
 .content-description-page p {
@@ -250,7 +256,7 @@ li {
 @media (min-width: 768px) {
     .content-description-page {
         padding: 0px;
-        margin: 0 128px 0 128px;
+        margin: 0 128px 64px 128px;
     }
 }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -102,6 +102,11 @@ i {
     padding-left: 0;
 }
 
+code {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 20px;
+}
+
 .about-area {
     /* Centre vertically */
     display:flex;

--- a/styles/style.css
+++ b/styles/style.css
@@ -246,7 +246,7 @@ li {
 .content-description-page {
     /* This class is mostly used for full-length
     content (i.e. no columns). Justify is used
-    here since on mobile, the text is squreezed
+    here since on mobile, the text is squeezed
     and so it looks like there is quite a fair
     amount of text and less "blank whitespaces"
     in between words. */


### PR DESCRIPTION
* Added notable works section
* Add small section on accessibility
* No artwork yet (to add later)
* Inherit font sizes rather than hard code
* Use `<code>` for well...code-y words
* Justify text on mobile for classes with expected long paragraphs (`content-description-page`, see comment below)

> Justify is used here since on mobile, the text is squeezed and so it looks like there is quite a fair amount of text and less "blank whitespaces" in between words.

![image](https://user-images.githubusercontent.com/31680656/121262702-26452b80-c8e7-11eb-8325-9de468aeda4d.png)
![image](https://user-images.githubusercontent.com/31680656/121263078-b1bebc80-c8e7-11eb-946b-eaf6a8a5222e.png)
