### PR TITLE
Better contrast for links and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
       </div>
     </div>
 
-    <div class="content-area">
+    <div class="content-area" id="main-content-area">
       <div class="container">
         <div class="row align-items-center" id="contributor-row">
           <div class="col-md content-heading">

--- a/styles/links.css
+++ b/styles/links.css
@@ -7,7 +7,7 @@
 
 .link-blueberry {
     background-color: var(--blueberry-100);
-    color: var(--black-100);
+    color: var(--black-300);
 }
 
 .link-blueberry:hover {
@@ -22,7 +22,7 @@
 
 .link-silver {
     background-color: var(--silver-300);
-    color: var(--black-100);
+    color: var(--black-300);
 }
 
 .link-silver:hover {

--- a/styles/style.css
+++ b/styles/style.css
@@ -107,6 +107,7 @@ code {
     but Roboto Mono pairs quite well with it */
     font-family: 'Roboto Mono', monospace;
     font-size: inherit;
+    color: var(--strawberry-500);
 }
 
 .content-area {
@@ -115,7 +116,6 @@ code {
     align-items: center;
 
     text-align: center;
-    color: var(--black-100);
     padding: 64px 12px 64px 12px;
     height: auto;
 }
@@ -216,8 +216,12 @@ code {
     font-weight: 500;
 }
 
+#main-content-area {
+    color: var(--black-100);
+}
+
 #footer {
-    color: var(--silver-100);
+    color: white;
     background-color: var(--cocoa-100);
     height: auto;
 }


### PR DESCRIPTION
Better contrast for links and footer.

Before:
![image](https://user-images.githubusercontent.com/31680656/123835410-11364800-d93b-11eb-8035-424d344bcc65.png)

After:
![image](https://user-images.githubusercontent.com/31680656/123835498-31fe9d80-d93b-11eb-8e07-a826f97a5b70.png)
